### PR TITLE
build warning fixes

### DIFF
--- a/Source/cmGlobalFastbuildGenerator.h
+++ b/Source/cmGlobalFastbuildGenerator.h
@@ -55,6 +55,12 @@ public:
 	virtual void ComputeTargetObjectDirectory(cmGeneratorTarget*) const;
 	virtual const char* GetCMakeCFGIntDir() const;
 
+	virtual void GetTargetSets(TargetDependSet& projectTargets,
+							   TargetDependSet& originalTargets,
+							   cmLocalGenerator* root, GeneratorVector const&);
+
+	const std::vector<std::string> & GetConfigurations() const;
+
 private:
 	class Factory;
 	class Detail;


### PR DESCRIPTION
It's a bit sucky, but the default compilation using gcc seems to be pedantic.  These are fixes for all of the warnings that come up plus some extra fixes for access to inaccessible/protected members (there may be more of the latter).
