### PR TITLE
fixed RC generation 

### DIFF
--- a/Source/cmGlobalFastbuildGenerator.cxx
+++ b/Source/cmGlobalFastbuildGenerator.cxx
@@ -2339,6 +2339,11 @@ public:
 					context.fc.WriteVariable("CompileFlags", Quote( command.flags ));
 					context.fc.WriteVariable("CompilerOptions", Quote("$CompileFlags$ $CompileDefineFlags$ $CompilerCmdBaseFlags$"));
 
+					if(objectGroupLanguage == "RC")
+					{
+						context.fc.WriteVariable("CompilerOutputExtension", Quote( ".res" ));
+					}
+
 					/*
 					if (Detection::DetectPrecompiledHeader(command.flags + " " + 
 						baseCompileFlags + " " + command.defines,


### PR DESCRIPTION
when resource file has the same name as a source file

e.g. test.cxx and test.rc were both compiled to test.obj.
now test.rc is compiled to test.res
