### PR TITLE
Exclude Fastbuild from the CMP0021 test

### DIFF
--- a/Tests/IncludeDirectories/CMakeLists.txt
+++ b/Tests/IncludeDirectories/CMakeLists.txt
@@ -87,6 +87,6 @@ if (NOT incs STREQUAL ";/one/two")
   message(SEND_ERROR "Empty include_directories entry was not ignored.")
 endif()
 
-if(NOT CMAKE_GENERATOR STREQUAL Xcode AND NOT CMAKE_GENERATOR STREQUAL Ninja)
+if(NOT CMAKE_GENERATOR STREQUAL Xcode AND NOT CMAKE_GENERATOR STREQUAL Ninja AND NOT CMAKE_GENERATOR STREQUAL Fastbuild)
   add_subdirectory(CMP0021)
 endif()


### PR DESCRIPTION
This is the same as done with Ninja and Xcode, it seems the natural way to address this issue
