### PR TITLE
Source groups now work

### DIFF
--- a/Source/cmGlobalFastbuildGenerator.cxx
+++ b/Source/cmGlobalFastbuildGenerator.cxx
@@ -1,76 +1,69 @@
 
 /*============================================================================
-  CMake - Cross Platform Makefile Generator
-  Copyright 2000-2009 Kitware, Inc., Insight Software Consortium
+	CMake - Cross Platform Makefile Generator
+	Copyright 2000-2009 Kitware, Inc., Insight Software Consortium
 
-  Distributed under the OSI-approved BSD License (the "License");
-  see accompanying file Copyright.txt for details.
+	Distributed under the OSI-approved BSD License (the "License");
+	see accompanying file Copyright.txt for details.
 
-  This software is distributed WITHOUT ANY WARRANTY; without even the
-  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  See the License for more information.
+	This software is distributed WITHOUT ANY WARRANTY; without even the
+	implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+	See the License for more information.
 ============================================================================*/
 /*============================================================================
-  Development progress:
+	Development progress:
 
-  Tasks/Issues:
-   - Execute unit tests against the generator somehow
-   - Fix target aliases being repeated in the output
-   - Fix cmake build using fastbuild (currently appears configuration incorrect)
-   - Running some of the Cmake generation, the pdb files can't be deleted (shows up errors)
-   - Depends upon visual studio generator code to sort dependencies
-   - When generating CMAKE from scratch, it sometimes errors with fortran complaints and fails generation?
+	Tasks/Issues:
+	 - Execute unit tests against the generator somehow
+	 - Fix target aliases being repeated in the output
+	 - Fix cmake build using fastbuild (currently appears configuration incorrect)
+	 - Running some of the Cmake generation, the pdb files can't be deleted (shows up errors)
+	 - Depends upon visual studio generator code to sort dependencies
+	 - When generating CMAKE from scratch, it sometimes errors with fortran complaints and fails generation?
 	 a re-run will succeed.
-   - Linker for msvc uses the cmake command to callback. Don't think this is an issue since
+	 - Linker for msvc uses the cmake command to callback. Don't think this is an issue since
 	 I think compilation is the part that gets distributed anyway.
-	 But it might mean that the cache has trouble calculating deps for obj->lib/exe. 
+	 But it might mean that the cache has trouble calculating deps for obj->lib/exe.
 	 Not sure if Fastbuild supports that anyway yet
-   - Need to sort custom build commands by their outputs
-   
-  Fastbuild bugs:
-   - Defining prebuild dependencies that don't exist, causes the error output when that 
-	 target is actually defined. Rather than originally complaining that the target 
+	 - Need to sort custom build commands by their outputs
+
+	Fastbuild bugs:
+	 - Defining prebuild dependencies that don't exist, causes the error output when that
+	 target is actually defined. Rather than originally complaining that the target
 	 doesn't exist where the reference is attempted.
-   - Parsing strings with double $$ doesn't generate a nice error
-   - Undocumented that you can escape a $ with ^$
-   - ExecInputs is invalid empty
-   - Would be great if you could define dummy targets (maybe blank aliases?)
-   - Exec nodes need to not worry about dummy output files not being created
-   - Would be nice if nodes didn't need to be completely in order. But then cycles would be possible
-   - Implib directory is not created for exeNodes (DLLs work now though)
+	 - Parsing strings with double $$ doesn't generate a nice error
+	 - Undocumented that you can escape a $ with ^$
+	 - ExecInputs is invalid empty
+	 - Would be great if you could define dummy targets (maybe blank aliases?)
+	 - Exec nodes need to not worry about dummy output files not being created
+	 - Would be nice if nodes didn't need to be completely in order. But then cycles would be possible
+	 - Implib directory is not created for exeNodes (DLLs work now though)
 
-  Limitations:
-   - Only tested/working with MSVC
+	Limitations:
+	 - Only tested/working with MSVC
 
-  Notes:
-   - Understanding Custom Build Steps and Build Events
-     https://msdn.microsoft.com/en-us/library/e85wte0k.aspx
+	Notes:
+	 - Understanding Custom Build Steps and Build Events
+		 https://msdn.microsoft.com/en-us/library/e85wte0k.aspx
 	 very useful documentation detailing the order of execution
 	 of standard MSVC events. This is useful to determine correct
 	 behaviour of fastbuild generator (view a project generated to MSVC,
-	 then apply the same rules/assumptions back into fastbuild). 
+	 then apply the same rules/assumptions back into fastbuild).
 	 i.e. Custom rules are always executed first.
 
-  Current list of unit tests failing:
+	Current list of unit tests failing:
 
-	89% tests passed, 41 tests failed out of 368
-	Total Test time (real) = 8386.39 sec
+	91% tests passed, 32 tests failed out of 371
+	Total Test time (real) = 1479.86 sec
 
-	The following tests FAILED:
-	58 - SourceGroups (Failed)
-	59 - Preprocess (Failed)
-	60 - ExportImport (Failed)
-	68 - StagingPrefix (Failed)
-	70 - ConfigSources (Failed)
-	78 - Module.ExternalData (Timeout)
-	79 - Module.GenerateExportHeader (Failed)
-	100 - SubProject (Failed)
+The following tests FAILED:
+	 59 - Preprocess (Failed)
+	 60 - ExportImport (Failed)
+	 68 - StagingPrefix (Failed)
+	 70 - ConfigSources (Failed)
+	 79 - Module.GenerateExportHeader (Failed)
 	101 - SubProject-Stage2 (Failed)
-	107 - GeneratorExpression (Failed)
-	108 - CustomCommand (Timeout)
-	109 - CustomCommandByproducts (Timeout)
-	112 - OutOfSource (Failed)
-	113 - BuildDepends (Timeout)
+	113 - BuildDepends (Failed)
 	114 - SimpleInstall (Failed)
 	115 - SimpleInstall-Stage2 (Failed)
 	127 - complex (Failed)
@@ -80,24 +73,22 @@
 	133 - ExternalProjectUpdateSetup (Failed)
 	134 - ExternalProjectUpdate (Failed)
 	151 - Plugin (Failed)
-	154 - SubDir (Failed)
 	156 - PDBDirectoryAndName (Failed)
 	157 - PrecompiledHeader (Failed)
 	158 - ModuleDefinition (Failed)
-	182 - CTestConfig.Script.Debug (Failed)
-	183 - CTestConfig.Dashboard.Debug (Failed)
-	184 - CTestConfig.Script.MinSizeRel (Failed)
-	185 - CTestConfig.Dashboard.MinSizeRel (Failed)
-	186 - CTestConfig.Script.Release (Failed)
-	187 - CTestConfig.Dashboard.Release (Failed)
-	188 - CTestConfig.Script.RelWithDebInfo (Failed)
-	189 - CTestConfig.Dashboard.RelWithDebInfo (Failed)
-	195 - CMakeCommands.target_compile_options (Failed)
-	221 - Java (Failed)
-	223 - IncludeDirectories (Failed)
-	237 - CMakeOnly.CheckStructHasMember (Failed)
-	274 - RunCMake.Configure (Failed)
-	330 - RunCMake.File_Generate (Failed)
+	184 - CTestConfig.Script.Debug (Failed)
+	185 - CTestConfig.Dashboard.Debug (Failed)
+	186 - CTestConfig.Script.MinSizeRel (Failed)
+	187 - CTestConfig.Dashboard.MinSizeRel (Failed)
+	188 - CTestConfig.Script.Release (Failed)
+	189 - CTestConfig.Dashboard.Release (Failed)
+	190 - CTestConfig.Script.RelWithDebInfo (Failed)
+	191 - CTestConfig.Dashboard.RelWithDebInfo (Failed)
+	197 - CMakeCommands.target_compile_options (Failed)
+	238 - CMakeOnly.CheckStructHasMember (Failed)
+	275 - RunCMake.Configure (Failed)
+	331 - RunCMake.File_Generate (Failed)
+	371 - CMake.CheckSourceTree (Failed)
 ============================================================================*/
 #include "cmGlobalFastbuildGenerator.h"
 
@@ -262,7 +253,6 @@ private:
 class cmGlobalFastbuildGenerator::Detail::Detection
 {
 public:
-
 	static std::string GetLastFolderName(const std::string& string)
 	{
 		return string.substr(string.rfind('/'));
@@ -2036,7 +2026,7 @@ public:
 	{
 		std::string defines;
 		std::string flags;
-		std::vector<std::string> sourceFiles;
+		std::map<std::string, std::vector<std::string> > sourceFiles;
 	};
 
 	static void WriteTargetDefinition(GenerationContext& context,
@@ -2219,14 +2209,6 @@ public:
 
 				context.fc.WriteBlankLine();
 				context.fc.WriteComment("Compiler options:");
-				{
-					// Tie together the variables
-					std::string targetCompileOutDirectory =
-						Detection::DetectTargetCompileOutputDir(lg, target, configName);
-					context.fc.WriteVariable("CompilerOutputPath", Quote(targetCompileOutDirectory));
-
-					std::string compileObjectCmd = Detection::DetectCompileRule(lg, target, objectGroupLanguage);
-				}
 
 				// Compiler options
 				std::string baseCompileFlags;
@@ -2283,7 +2265,7 @@ public:
 
 						std::string configKey = compilerFlags + "{|}" + compileDefines;
 						CompileCommand& command = commandPermutations[configKey];
-						command.sourceFiles.push_back(sourceFile);
+						command.sourceFiles[srcFile->GetLocation().GetDirectory()].push_back(sourceFile);
 						command.flags = compilerFlags;
 						command.defines = compileDefines;
 					}
@@ -2297,19 +2279,9 @@ public:
 					groupIter != commandPermutations.end();
 					++groupIter)
 				{
-					const CompileCommand& command = groupIter->second;
-					std::stringstream ruleName;
-					ruleName << objectGroupRuleName << "-" << (groupNameCount++);
-					configObjectGroups.push_back(ruleName.str());
-
-					context.fc.WriteCommand("ObjectList", Quote(ruleName.str()));
 					context.fc.WritePushScope();
 
-					context.fc.WriteArray("CompilerInputFiles", 
-						Wrap(command.sourceFiles, "'", "'"));
-
-					// Unity source files:
-					context.fc.WriteVariable("UnityInputFiles", ".CompilerInputFiles");
+					const CompileCommand& command = groupIter->second;
 
 					context.fc.WriteVariable("CompileDefineFlags", Quote( command.defines ));
 					context.fc.WriteVariable("CompileFlags", Quote( command.flags ));
@@ -2319,16 +2291,44 @@ public:
 					{
 						context.fc.WriteVariable("CompilerOutputExtension", Quote( ".res" ));
 					}
+					else
+					{
+						context.fc.WriteVariable("CompilerOutputExtension", Quote( "." + objectGroupLanguage + ".obj" ));
+					}
 
-					/*
-					if (Detection::DetectPrecompiledHeader(command.flags + " " + 
-						baseCompileFlags + " " + command.defines,
-						preCompiledHeaderInput,
-						preCompiledHeaderOutput,
-						preCompiledHeaderOptions)
-					*/
+					std::map<std::string, std::vector<std::string> >::const_iterator objectListIt;
+					for(objectListIt = command.sourceFiles.begin(); objectListIt != command.sourceFiles.end(); ++objectListIt)
+					{
+						const std::string folderName(Detection::GetLastFolderName(objectListIt->first));
+						std::stringstream ruleName;
+						ruleName << objectGroupRuleName << "-" << folderName << "-" << (groupNameCount++);
+
+						context.fc.WriteCommand("ObjectList", Quote(ruleName.str()));
+						context.fc.WritePushScope();
+
+						context.fc.WriteArray("CompilerInputFiles",
+							Wrap(objectListIt->second, "'", "'"));
+
+						configObjectGroups.push_back(ruleName.str());
+
+						std::string targetCompileOutDirectory =
+							Detection::DetectTargetCompileOutputDir(lg, target, configName);
+						context.fc.WriteVariable("CompilerOutputPath", Quote(targetCompileOutDirectory + "/" + folderName));
+
+						// Unity source files:
+						context.fc.WriteVariable("UnityInputFiles", ".CompilerInputFiles");
+
+						/*
+						if (Detection::DetectPrecompiledHeader(command.flags + " " +
+							baseCompileFlags + " " + command.defines,
+							preCompiledHeaderInput,
+							preCompiledHeaderOutput,
+							preCompiledHeaderOptions)
+						*/
+						context.fc.WritePopScope();
+					}
+
 					context.fc.WritePopScope();
-
 				}
 
 				if(!configObjectGroups.empty()) {


### PR DESCRIPTION
This brings the test status to the following:

91% tests passed, 35 tests failed out of 371

Label Time Summary:
Label1    =   0.46 sec
Label2    =   0.46 sec

Total Test time (real) = 1134.95 sec

The following tests FAILED:
         59 - Preprocess (Failed)
         60 - ExportImport (Failed)
         68 - StagingPrefix (Failed)
         70 - ConfigSources (Failed)
         79 - Module.GenerateExportHeader (Failed)
        100 - SubProject (Failed)
        101 - SubProject-Stage2 (Failed)
        113 - BuildDepends (Failed)
        114 - SimpleInstall (Failed)
        115 - SimpleInstall-Stage2 (Failed)
        127 - complex (Failed)
        128 - complexOneConfig (Failed)
        131 - ExternalProject (Failed)
        132 - ExternalProjectLocal (Failed)
        133 - ExternalProjectUpdateSetup (Failed)
        134 - ExternalProjectUpdate (Failed)
        151 - Plugin (Failed)
        154 - SubDir (Failed)
        156 - PDBDirectoryAndName (Failed)
        157 - PrecompiledHeader (Failed)
        158 - ModuleDefinition (Failed)
        184 - CTestConfig.Script.Debug (Failed)
        185 - CTestConfig.Dashboard.Debug (Failed)
        186 - CTestConfig.Script.MinSizeRel (Failed)
        187 - CTestConfig.Dashboard.MinSizeRel (Failed)
        188 - CTestConfig.Script.Release (Failed)
        189 - CTestConfig.Dashboard.Release (Failed)
        190 - CTestConfig.Script.RelWithDebInfo (Failed)
        191 - CTestConfig.Dashboard.RelWithDebInfo (Failed)
        197 - CMakeCommands.target_compile_options (Failed)
        238 - CMakeOnly.CheckStructHasMember (Failed)
        275 - RunCMake.Configure (Failed)
        331 - RunCMake.File_Generate (Failed)
        371 - CMake.CheckSourceTree (Failed)
#156 is a head scratcher, I tried running it specifically on the current head, and it does not work either.

No idea why it did not show up before, as I don't think it could have worked
